### PR TITLE
Bugfix: note.tupletId gets out of sync with tuplet.id after deserialization

### DIFF
--- a/src/smo/data/measure.ts
+++ b/src/smo/data/measure.ts
@@ -682,6 +682,10 @@ export class SmoMeasure implements SmoMeasureParams, TickMappable {
         params.tupletTrees.push(tupletTree);
       }
     }
+    if (params.tupletTrees.length) {
+      SmoTupletTree.syncTupletIds(params.tupletTrees, voices)
+    }
+
     params.modifiers = modifiers;
     const measure = new SmoMeasure(params);
     // Handle migration for measure-mapped parameters

--- a/src/smo/data/tuplet.ts
+++ b/src/smo/data/tuplet.ts
@@ -9,7 +9,7 @@ import { SmoNote, SmoNoteParamsSer, TupletInfo } from './note';
 import { SmoMusic } from './music';
 import { SmoNoteModifierBase } from './noteModifiers';
 import { getId, SmoAttrs, Clef } from './common';
-import { SmoMeasure } from './measure';
+import {SmoMeasure, SmoVoice} from './measure';
 import {tuplets} from "vexflow_smoosic/build/esm/types/tests/formatter/tests";
 
 
@@ -37,6 +37,26 @@ export class SmoTupletTree {
 
   constructor(params: SmoTupletTreeParams) {
     this.tuplet = params.tuplet;
+  }
+
+  static syncTupletIds(tupletTrees: SmoTupletTree[], voices: SmoVoice[]) {
+    const traverseTupletTree = (parentTuplet: SmoTuplet): void => {
+      const notes: SmoNote[] = voices[parentTuplet.voice].notes;
+      for (let i = parentTuplet.startIndex; i <= parentTuplet.endIndex; i++) {
+        const note: SmoNote = notes[i];
+        note.tupletId = parentTuplet.attrs.id;
+      }
+      for (let i = 0; i < parentTuplet.childrenTuplets.length; i++) {
+        const tuplet = parentTuplet.childrenTuplets[i];
+        traverseTupletTree(tuplet);
+      }
+    };
+
+    //traverse tuplet tree
+    for (let i = 0; i < tupletTrees.length; i++) {
+      const tupletTree: SmoTupletTree = tupletTrees[i];
+      traverseTupletTree(tupletTree.tuplet);
+    }
   }
 
   static adjustTupletIndexes(tupletTrees: SmoTupletTree[], voice: number, startTick: number, diff: number) {

--- a/src/smo/mxml/xmlToSmo.ts
+++ b/src/smo/mxml/xmlToSmo.ts
@@ -19,6 +19,7 @@ import { Pitch, PitchKey, Clef } from '../data/common';
 import { SmoOperation } from '../xform/operations';
 import { SmoInstrument, SmoSlur, SmoTie, TieLine } from '../data/staffModifiers';
 import { SmoPartInfo } from '../data/partInfo';
+import {SmoTupletTree} from "../data/tuplet";
 
 /**
  * A class that takes a music XML file and outputs a {@link SmoScore}
@@ -805,6 +806,7 @@ export class XmlToSmo {
         const voiceId = smoMeasure.voices.length - 1;
         xmlState.addTupletsToMeasure(smoMeasure, staffData.clefInfo.staffId, voiceId);
       });
+      SmoTupletTree.syncTupletIds(smoMeasure.tupletTrees, smoMeasure.voices);
       if (smoMeasure.voices.length === 0) {
         smoMeasure.voices.push({ notes: SmoMeasure.getDefaultNotes(smoMeasure) });
       }


### PR DESCRIPTION
As the title says, note.tupletId gets out of sync with tuplet.id after deserialization. Since IDs are always regenerated, regardless of whether they are new or cloned, we need to ensure they remain in sync.